### PR TITLE
feat: Add form to get tweet by id and error handling

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,0 +1,8 @@
+<script lang='ts'>
+	let id = $state('');
+</script>
+
+<form action={`/${id}`} method='GET'>
+	<input type='text' bind:value={id} />
+	<button type='submit'>Go</button>
+</form>

--- a/src/routes/[id]/+page.server.ts
+++ b/src/routes/[id]/+page.server.ts
@@ -4,6 +4,11 @@ import type { RequestEvent } from './$types';
 
 export async function load({ params }: RequestEvent) {
 	const { id } = params;
+
+	if (id !== '') {
+		return error(404, 'Tweet not found');
+	}
+
 	try {
 		const tweet = await getTweet(id);
 


### PR DESCRIPTION
This commit introduces a form in `+page.svelte` that allows users to
enter a tweet id and fetch the corresponding tweet. It also adds error
handling in `+page.server.ts` to return a 404 error when the tweet id
is not found.
