### PR TITLE
feat: add await-to-js for error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"@sveltejs/kit": "^2.5.18",
 		"@sveltejs/package": "^2.3.2",
 		"@sveltejs/vite-plugin-svelte": "^3.1.1",
+		"await-to-js": "^3.0.0",
 		"eslint": "^9.8.0",
 		"eslint-plugin-format": "^0.1.2",
 		"eslint-plugin-svelte": "^2.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.1
         version: 3.1.1(svelte@5.0.0-next.201)(vite@4.5.3)
+      await-to-js:
+        specifier: ^3.0.0
+        version: 3.0.0
       eslint:
         specifier: ^9.8.0
         version: 9.8.0
@@ -842,6 +845,10 @@ packages:
 
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
+  await-to-js@3.0.0:
+    resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
+    engines: {node: '>=6.0.0'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3229,6 +3236,8 @@ snapshots:
   array-union@2.1.0: {}
 
   async-sema@3.1.1: {}
+
+  await-to-js@3.0.0: {}
 
   axobject-query@4.1.0: {}
 

--- a/src/routes/[id]/+page.server.ts
+++ b/src/routes/[id]/+page.server.ts
@@ -1,5 +1,6 @@
 import { getTweet } from 'react-tweet/api';
 import { error } from '@sveltejs/kit';
+import to from 'await-to-js';
 import type { RequestEvent } from './$types';
 
 export async function load({ params }: RequestEvent) {
@@ -9,18 +10,15 @@ export async function load({ params }: RequestEvent) {
 		return error(404, 'Tweet not found');
 	}
 
-	try {
-		const tweet = await getTweet(id);
+	const [err, tweet] = await to(getTweet(id));
 
-		if (tweet == null) {
-			return error(404, 'Tweet not found');
-		}
-
-		return {
-			tweet,
-		};
-	}
-	catch {
+	if (err != null) {
 		return error(500, 'Could not load tweet');
 	}
+
+	if (tweet == null) {
+		return error(404, 'Tweet not found');
+	}
+
+	return { tweet };
 }


### PR DESCRIPTION
This commit introduces the await-to-js library to the project. It is used to handle errors in a more elegant way by using array destructuring. This change is applied in the `getTweet` function in `+page.server.ts` and `EmbeddedTweet.svelte`. The package.json and pnpm-lock.yaml files are updated to include the new dependency.