### PR TITLE
feat: Add dark mode toggle to Tweet page

### DIFF
--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -2,6 +2,15 @@
 	import Tweet from '$lib/components/Tweet.svelte';
 
 	const { data } = $props();
+
+	let isDark = $state(false);
 </script>
 
-<Tweet tweet={data.tweet} />
+<div>
+	<input id='dark-mode' type='checkbox' bind:checked={isDark} />
+	<label for='dark-mode'>Dark mode</label>
+</div>
+
+<div data-theme={isDark ? 'dark' : 'light'}>
+	<Tweet tweet={data.tweet} />
+</div>


### PR DESCRIPTION
This commit introduces a new feature where users can toggle between
dark and light modes on the Tweet page. A checkbox has been added for
this purpose. The theme of the Tweet component changes based on the
state of this checkbox.
