### PR TITLE
feat(ci): add publish step to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,3 +24,5 @@ jobs:
         run: pnpm check
       - name: Run lint
         run: pnpm lint
+      - name: publish to pkg-pr-now
+        run: pnpm dlx pkg-pr-new publish


### PR DESCRIPTION
This commit adds a new step to the GitHub Actions CI workflow. This step
publishes the package using the `pkg-pr-new` tool. This change will
automate the publishing process, making it more efficient.
