### PR TITLE
chore(deps): Move await-to-js to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"svelte": "^5.0.0"
 	},
 	"dependencies": {
+		"await-to-js": "^3.0.0",
 		"scn": "^1.0.19"
 	},
 	"devDependencies": {
@@ -46,7 +47,6 @@
 		"@sveltejs/kit": "^2.5.18",
 		"@sveltejs/package": "^2.3.2",
 		"@sveltejs/vite-plugin-svelte": "^3.1.1",
-		"await-to-js": "^3.0.0",
 		"eslint": "^9.8.0",
 		"eslint-plugin-format": "^0.1.2",
 		"eslint-plugin-svelte": "^2.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      await-to-js:
+        specifier: ^3.0.0
+        version: 3.0.0
       scn:
         specifier: ^1.0.19
         version: 1.0.19
@@ -30,9 +33,6 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.1
         version: 3.1.1(svelte@5.0.0-next.201)(vite@4.5.3)
-      await-to-js:
-        specifier: ^3.0.0
-        version: 3.0.0
       eslint:
         specifier: ^9.8.0
         version: 9.8.0

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {


### PR DESCRIPTION
This commit moves the 'await-to-js' package from devDependencies to
dependencies in package.json. The corresponding changes are also reflected
in pnpm-lock.yaml. Additionally, an unnecessary eslint-disable comment
is removed from src/app.d.ts.
