### PR TITLE
refactor: streamline Svelte class bindings and import paths

### DIFF
--- a/src/lib/components/EmbeddedTweet.svelte
+++ b/src/lib/components/EmbeddedTweet.svelte
@@ -2,7 +2,6 @@
 	import type { Tweet } from 'react-tweet/api';
 	import type { EnrichedTweet } from 'react-tweet';
 	import { enrichTweet } from 'react-tweet';
-	import type { TwitterComponents } from '../types.js';
 	import TweetContainer from './TweetContainer.svelte';
 	import TweetHeader from './TweetHeader.svelte';
 	import TweetInReplyTo from './TweetInReply.svelte';
@@ -11,6 +10,7 @@
 	import TweetInfo from './TweetInfo.svelte';
 	import TweetActions from './TweetActions.svelte';
 	import TweetReplies from './TweetReplies.svelte';
+	import type { TwitterComponents } from '$lib/types.js';
 	import { building, dev } from '$app/environment';
 	// import QuotedTweet from './quoted-tweet/QuotedTweet.svelte';
 

--- a/src/lib/components/MediaImg.svelte
+++ b/src/lib/components/MediaImg.svelte
@@ -14,4 +14,10 @@
 	}: Props = $props();
 </script>
 
-<img class={className} {alt} {draggable} loading='lazy' {src} />
+<img
+	class={className}
+	{alt}
+	{draggable}
+	loading='lazy'
+	{src}
+/>

--- a/src/lib/components/TweetHeader.svelte
+++ b/src/lib/components/TweetHeader.svelte
@@ -18,9 +18,8 @@
 <div class='header'>
 	<a class='avatar' href={tweet.url} rel='noopener noreferrer' target='_blank'>
 		<div
-			class={user.profile_image_shape === 'Square'
-				? 'avatarOverflow avatarSquare'
-				: 'avatarOverflow'}
+			class='avatarOverflow'
+			class:avatarSquare={user.profile_image_shape === 'Square'}
 		>
 			<Img
 				style='margin-top: 0; margin-bottom: 0;'

--- a/src/lib/components/TweetMedia.svelte
+++ b/src/lib/components/TweetMedia.svelte
@@ -42,17 +42,15 @@
 
 <div class={['root', !quoted && 'rounded'].join(' ')}>
 	<div
-		class={[
-			'mediaWrapper',
-			length > 1 && 'grid2Columns',
-			length === 3 && 'grid3',
-			length > 4 && 'grid2x2',
-		].join(' ')}
+		class='mediaWrapper'
+		class:grid2Columns={length > 1}
+		class:grid2x2={length > 4}
+		class:grid3={length === 3}
 	>
 		{#each mediaDetails as media (media)}
 			{#if media.type === 'photo'}
 				<a
-					class={['mediaContainer', 'mediaLink'].join(' ')}
+					class='mediaContainer mediaLink'
 					href={tweet.url}
 					rel='noopener noreferrer'
 					target='_blank'


### PR DESCRIPTION
This commit refactors the Svelte class bindings in several components
to use Svelte's class directive for cleaner, more readable code. It
also updates the import paths for TwitterComponents to use SvelteKit's
$lib alias, improving the consistency and readability of import
statements. The MediaImg component has been updated to use a more
readable multi-line format for its attributes.
