### PR TITLE
feat: add dark mode toggle and styling

### DIFF
--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -4,13 +4,47 @@
 	const { data } = $props();
 
 	let isDark = $state(false);
+
+	$effect(() => {
+		if (isDark) {
+			window.document.body.classList.add('dark');
+		}
+		else {
+			window.document.body.classList.remove('dark');
+		}
+	});
 </script>
 
-<div>
-	<input id='dark-mode' type='checkbox' bind:checked={isDark} />
-	<label for='dark-mode'>Dark mode</label>
+<div id='container'>
+	<div>
+		<input id='dark-mode' type='checkbox' bind:checked={isDark} />
+		<label for='dark-mode'>Dark mode</label>
+	</div>
+
+	<div data-theme={isDark ? 'dark' : 'light'}>
+		<Tweet tweet={data.tweet} />
+	</div>
 </div>
 
-<div data-theme={isDark ? 'dark' : 'light'}>
-	<Tweet tweet={data.tweet} />
-</div>
+<style>
+	#container {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		height: 100vh;
+		flex-direction: column;
+	}
+
+	:global {
+		body {
+			background-color: #f2eee2;
+			color: #0084f6;
+			transition: background-color 0.3s
+		}
+
+		body.dark {
+			background-color: #1d3040;
+			color: #bfc2c7;
+		}
+	}
+</style>


### PR DESCRIPTION
This commit introduces a dark mode toggle to the application. When
the toggle is switched on, the body classList is updated to include
the 'dark' class. This class changes the background and text colors
for a darker theme. The layout of the page has also been updated to
center the content vertically and horizontally. The transition between
light and dark mode is animated with a 0.3s transition on the
background color.
