### PR TITLE
refactor(page.svelte): remove height style from container

### DIFF
--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -31,7 +31,6 @@
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		height: 100vh;
 		flex-direction: column;
 	}
 


### PR DESCRIPTION
The height style was removed from the container in the page.svelte file. This change was made to improve the layout flexibility and responsiveness of the page.
