### PR TITLE
refactor: Remove scn dependency and update class assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
 	"peerDependencies": {
 		"svelte": "^5.0.0"
 	},
-	"dependencies": {
-		"scn": "^1.0.19"
-	},
 	"devDependencies": {
 		"@ryoppippi/eslint-config": "npm:@jsr/ryoppippi__eslint-config@^0.0.21",
 		"@sveltejs/adapter-auto": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      scn:
-        specifier: ^1.0.19
-        version: 1.0.19
     devDependencies:
       '@ryoppippi/eslint-config':
         specifier: npm:@jsr/ryoppippi__eslint-config@^0.0.21
@@ -2016,9 +2012,6 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-
-  scn@1.0.19:
-    resolution: {integrity: sha512-xOpcug2SXyG4bFQTvA58/kExFNE/gHdy2NLhg/v9azjhar4i3/ig179+Ec/+jf3PpQC8clf33On0dd+NIkN3BQ==}
 
   scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
@@ -4448,8 +4441,6 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
-
-  scn@1.0.19: {}
 
   scslre@0.3.0:
     dependencies:

--- a/src/lib/components/TweetContainer.svelte
+++ b/src/lib/components/TweetContainer.svelte
@@ -1,6 +1,5 @@
 <script lang='ts'>
 	import type { Snippet } from 'svelte';
-	import scn from 'scn';
 	import 'react-tweet/theme.css';
 
 	type Props = {
@@ -8,11 +7,13 @@
 		children: Snippet;
 	};
 	const { className = '', children }: Props = $props();
-
-	const computedClass = scn('react-tweet-theme', 'root', className);
 </script>
 
-<div class={computedClass}>
+<div
+	class={className}
+	class:react-tweet-theme={true}
+	class:root={true}
+>
 	<article class='article'>
 		{@render children()}
 	</article>


### PR DESCRIPTION
This commit removes the 'scn' dependency from package.json and
pnpm-lock.yaml. The usage of 'scn' in TweetContainer.svelte has been
replaced with direct class assignment. This simplifies the code and
reduces the project's dependencies.
