### PR TITLE
refactor: remove unused constants.server.ts

### DIFF
--- a/src/lib/constants.server.ts
+++ b/src/lib/constants.server.ts
@@ -1,9 +1,0 @@
-/*
-    IMPORTANT NOTICE! -
-    This code is originally taken from Vercel's 'react-tweet' package.
-    It just has a bit of modifications to work on Svelte and suit my coding style.
-
-    Package URL: https://github.com/vercel/react-tweet
-*/
-
-export const TWEET_REGEX = /^\d+$/;


### PR DESCRIPTION
The file `constants.server.ts` was removed as it was no longer needed.
The TWEET_REGEX constant it contained was not being used anywhere in the
project. The original code was taken from Vercel's 'react-tweet' package,
but it was modified for use with Svelte and is no longer relevant.
