### PR TITLE
fix(TweetInfo): correct privacy info link (twitter -> x)

### DIFF
--- a/src/lib/components/TweetInfo.svelte
+++ b/src/lib/components/TweetInfo.svelte
@@ -10,7 +10,7 @@
 	<a
 		class='infoLink'
 		aria-label='Twitter for Websites, Ads Information and Privacy'
-		href='https://help.twitter.com/en/twitter-for-websites-ads-info-and-privacy'
+		href='https://help.x.com/en/x-for-websites-ads-info-and-privacy'
 		rel='noopener noreferrer'
 		target='_blank'
 	>


### PR DESCRIPTION
The privacy information link in the TweetInfo component was previously
pointing to an incorrect URL. This commit corrects the link to point to
the updated URL.
