### PR TITLE
fix(ci): add build process for pkg-pr-now

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,5 +23,16 @@ jobs:
         run: pnpm check
       - name: Run lint
         run: pnpm lint
-      - name: publish to pkg-pr-now
-        run: pnpm dlx pkg-pr-new publish
+
+  pkg-pr-now:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm dlx pkg-pr-new publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   lint:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The condition that prevented the lint job from running on draft pull
requests has been removed. This allows linting to occur regardless of
the pull request status, ensuring consistent code quality.