### PR TITLE
refactor: fix exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ The best way to embed tweets in your SvelteKit app, supporting both SSR and stat
 
 > This package is a sveltekit version of [vercel/react-tweet](https://github.com/vercel/react-tweet) licensed under MIT License, many thanks to the original authors for making it possible!
 
+# Requirements
+- SvelteKit 2.0.0 or later
+- Svelte 5.0.0-next or later ( This libray uses [`runes`](https://svelte-5-preview.vercel.app/docs/runes) )
+
 ## Installation
 
 ```bash
-npm install sveltekit-tweet
+npx nypm add @ryoppippi/sveltekit-tweet
 ```
 
 ## Usage
@@ -21,7 +25,7 @@ npm install sveltekit-tweet
 2.  Use the `getTweet` function in your `+page.server.ts` file to fetch the tweet data.
 
     ```ts
-    import { getTweet } from 'react-tweet/api';
+    import { getTweet } from '@ryoppippi/sveltekit-tweet/api';
     import { error } from '@sveltejs/kit';
     import type { RequestEvent } from './$types';
 
@@ -30,9 +34,7 @@ npm install sveltekit-tweet
         try {
             const tweet = await getTweet(id);
 
-            return {
-                tweet,
-            };
+            return { tweet };
         }
         catch {
             return error(500, 'Could not load tweet');
@@ -41,21 +43,17 @@ npm install sveltekit-tweet
 
     ```
 
-3.  Use the `Tweet` component in your `+page.svelte` file to render the tweet.
+3.  Use the `SvelteTweet` component in your `+page.svelte` file to render the tweet.
 
     ```svelte
     <script lang='ts'>
-    	import Tweet from 'sveltekit-tweet/server';
+    	import { SvelteTweet } from '@ryoppippi/sveltekit-tweet';
     	import type { PageData } from './$types';
 
-    	export let data: PageData;
+        const { data }: { data: PageData } = $props()
     </script>
 
-    {#if data.tweet}
-    	<Tweet tweet={data.tweet} />
-    {:else if data.error}
-    	<p>{data.error}</p>
-    {/if}
+    <SvelteTweet tweet={data.tweet} />
     ```
 
 # Acknowledgements

--- a/src/lib/components/EmbeddedTweet.svelte
+++ b/src/lib/components/EmbeddedTweet.svelte
@@ -10,17 +10,12 @@
 	import TweetActions from './TweetActions.svelte';
 	import TweetReplies from './TweetReplies.svelte';
 	import { QuotedTweet } from './quoted';
-	import { dev } from '$app/environment';
 
 	type Props = {
 		tweet: Tweet;
 	};
 
 	const { tweet }: Props = $props();
-
-	if (dev) {
-		console.info(`using tweet ${JSON.stringify(tweet)}`); // eslint-disable-line no-console
-	}
 
 	const enrichedTweet = enrichTweet(tweet);
 </script>

--- a/src/lib/components/quoted/Container.svelte
+++ b/src/lib/components/quoted/Container.svelte
@@ -1,7 +1,6 @@
 <script lang='ts'>
 	import type { EnrichedQuotedTweet } from 'react-tweet';
 	import type { Snippet } from 'svelte';
-	import { browser } from '$app/environment';
 
 	type Props = { tweet: EnrichedQuotedTweet; children: Snippet };
 
@@ -13,9 +12,6 @@
 <div
 	class='root'
 	onclick={(e) => {
-		if (!browser) {
-			return;
-		}
 		e.preventDefault();
 		window.open(tweet.url, '_blank');
 	}}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,4 +6,6 @@
     Package URL: https://github.com/vercel/react-tweet
 */
 
-export { getTweet } from 'react-tweet/api';
+export { default as SvelteTweet } from './components/Tweet.svelte';
+export type { EnrichedTweet } from 'react-tweet';
+export type * from 'react-tweet/api';

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -6,4 +6,5 @@
     Package URL: https://github.com/vercel/react-tweet
 */
 
-export { default as Tweet } from './components/Tweet.svelte';
+export { getTweet } from 'react-tweet/api';
+export type * from 'react-tweet/api';

--- a/src/routes/[id]/+page.server.ts
+++ b/src/routes/[id]/+page.server.ts
@@ -1,4 +1,4 @@
-import { getTweet } from 'react-tweet/api';
+import { type Tweet, getTweet } from 'react-tweet/api';
 import { error } from '@sveltejs/kit';
 import type { RequestEvent } from './$types';
 
@@ -14,6 +14,8 @@ export async function load({ params }: RequestEvent) {
 	if (tweet == null) {
 		return error(404, 'Tweet not found');
 	}
+
+	tweet satisfies Tweet;
 
 	return { tweet };
 }

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang='js'>
 	import ToggleDark from './ToggleDark.svelte';
-	import Tweet from '$components/Tweet.svelte';
+	import { SvelteTweet } from '$lib';
 
 	const { data } = $props();
 
@@ -26,7 +26,7 @@
 <div id='container'>
 	<ToggleDark />
 
-	<Tweet tweet={data.tweet} />
+	<SvelteTweet tweet={data.tweet} />
 </div>
 
 <style>


### PR DESCRIPTION
The check for the browser environment in the onclick event handler
was removed from Container.svelte. This check was unnecessary as
SvelteKit handles environment differences internally.