### PR TITLE
feat: Convert package from SvelteKit to Svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# SvelteKit Tweet
+# Svelte Tweet
 
-The best way to embed tweets in your SvelteKit app, supporting both SSR and static prerendering modes.
+The best way to embed tweets in your Svelte app, supporting both SSR and static prerendering modes.
 
 - The tweet is loaded in the server-side.
 - No need for any additonal client-side scripts.
 - No need for any loading UI, the tweet is available immediately.
 - Supports both SSR and prerendering.
 
-> This package is a sveltekit version of [vercel/react-tweet](https://github.com/vercel/react-tweet) licensed under MIT License, many thanks to the original authors for making it possible!
+> This package is a Svelte version of [vercel/react-tweet](https://github.com/vercel/react-tweet) licensed under MIT License, many thanks to the original authors for making it possible!
 
 # Requirements
-- SvelteKit 2.0.0 or later
 - Svelte 5.0.0-next or later ( This libray uses [`runes`](https://svelte-5-preview.vercel.app/docs/runes) )
 
 ## Installation
@@ -21,11 +20,12 @@ npx nypm add @ryoppippi/sveltekit-tweet
 
 ## Usage
 
+### SvelteKit
 1.  Go to the tweet you want to embed. You will find the URL i
 2.  Use the `getTweet` function in your `+page.server.ts` file to fetch the tweet data.
 
     ```ts
-    import { getTweet } from '@ryoppippi/sveltekit-tweet/api';
+    import { getTweet } from 'svelte-tweet/api';
     import { error } from '@sveltejs/kit';
     import type { RequestEvent } from './$types';
 
@@ -47,7 +47,7 @@ npx nypm add @ryoppippi/sveltekit-tweet
 
     ```svelte
     <script lang='ts'>
-    	import { SvelteTweet } from '@ryoppippi/sveltekit-tweet';
+    	import { SvelteTweet } from 'svelte-tweet';
     	import type { PageData } from './$types';
 
         const { data }: { data: PageData } = $props()
@@ -55,6 +55,21 @@ npx nypm add @ryoppippi/sveltekit-tweet
 
     <SvelteTweet tweet={data.tweet} />
     ```
+
+### Svelte
+
+```svelte
+<script lang='ts'>
+    import { SvelteTweet } from 'svelte-tweet';
+    import { getTweet } from 'svelte-tweet/api';
+
+    const id = '';
+</script>
+
+{#await getTweet(id) then tweet}
+    <SvelteTweet tweet={data.tweet} />
+{/await}
+
 
 # Acknowledgements
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@ryoppippi/sveltekit-tweet",
+	"name": "svelte-tweet",
 	"type": "module",
 	"version": "0.1.0",
 	"packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e",


### PR DESCRIPTION
This commit changes the package from a SvelteKit specific package to a
general Svelte package. The package name is changed from
"@ryoppippi/sveltekit-tweet" to "svelte-tweet". The README is updated
to reflect these changes and to provide usage instructions for both
SvelteKit and Svelte. The import statements in the code examples are
also updated to use the new package name.
