### PR TITLE
refactor: remove unnecessary comments from source files

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,2 @@
-/*
-    IMPORTANT NOTICE! -
-    This code is originally taken from Vercel's 'react-tweet' package.
-    It just has a bit of modifications to work on Svelte and suit my coding style.
-
-    Package URL: https://github.com/vercel/react-tweet
-*/
-
 export { getTweet } from 'react-tweet/api';
 export type * from 'react-tweet/api';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,11 +1,3 @@
-/*
-    IMPORTANT NOTICE! -
-    This code is originally taken from Vercel's 'react-tweet' package.
-    It just has a bit of modifications to work on Svelte and suit my coding style.
-
-    Package URL: https://github.com/vercel/react-tweet
-*/
-
 export { default as SvelteTweet } from './components/Tweet.svelte';
 export type { EnrichedTweet } from 'react-tweet';
 export type * from 'react-tweet/api';


### PR DESCRIPTION
The comments indicating the original source of the code from Vercel's
'react-tweet' package have been removed from 'src/lib/api.ts' and
'src/lib/index.ts'. The code has been sufficiently modified to suit
the current project and the comments are no longer needed.
