### PR TITLE
refactor(TweetActionsCopy): remove unused effect comment

### DIFF
--- a/src/lib/components/TweetActionsCopy.svelte
+++ b/src/lib/components/TweetActionsCopy.svelte
@@ -3,6 +3,8 @@
 
 	const { tweet }: { tweet: EnrichedTweet } = $props();
 
+	const timeoutMs = 6000;
+
 	let copied = $state(false);
 
 	const handleCopy = () => {
@@ -16,7 +18,7 @@
 		if (copied) {
 			timeout = setTimeout(() => {
 				copied = false;
-			}, 6000);
+			}, timeoutMs);
 		}
 
 		return () => {

--- a/src/lib/components/TweetActionsCopy.svelte
+++ b/src/lib/components/TweetActionsCopy.svelte
@@ -4,7 +4,6 @@
 	const { tweet }: { tweet: EnrichedTweet } = $props();
 
 	let copied = $state(false);
-	let copyAllText = $state(false);
 
 	const handleCopy = () => {
 		navigator.clipboard.writeText(tweet.url);
@@ -17,7 +16,6 @@
 		if (copied) {
 			timeout = setTimeout(() => {
 				copied = false;
-				copyAllText = true;
 			}, 6000);
 		}
 
@@ -46,7 +44,7 @@
 		{/if}
 	</div>
 	<span class='copyText'>
-		{copied ? 'Copied!' : copyAllText ? 'Copy link to Tweet' : 'Copy link'}
+		{copied ? 'Copied!' : 'Copy link'}
 	</span>
 </button>
 

--- a/src/lib/components/TweetActionsCopy.svelte
+++ b/src/lib/components/TweetActionsCopy.svelte
@@ -25,17 +25,6 @@
 			clearTimeout(timeout);
 		};
 	});
-
-// $effect(() => {
-	// 	if (copied) {
-	// 		clearTimeout(timeout);
-	// 		timeout = setTimeout(() => {
-	// 			copied = false;
-	// 			copyAllText = true;
-	// 		}, 6000);
-	// 	}
-	// });
-
 </script>
 
 <button class='copy' aria-label='Copy link' onclick={handleCopy} type='button'>


### PR DESCRIPTION
The effect block that was commented out in TweetActionsCopy.svelte
has been removed. This block was previously used to handle the
state of the 'copied' and 'copyAllText' variables with a timeout.
Since it's not being used anymore, it's better to remove it to
keep the code clean and understandable.