### PR TITLE
refactor(TweetActionsCopy): move timeout inside effect

### DIFF
--- a/src/lib/components/TweetActionsCopy.svelte
+++ b/src/lib/components/TweetActionsCopy.svelte
@@ -12,18 +12,16 @@
 		copied = true;
 	};
 
-	let timeout: ReturnType<typeof setTimeout>;
-
 	$effect(() => {
 		if (copied) {
-			timeout = setTimeout(() => {
+			const timeout = setTimeout(() => {
 				copied = false;
 			}, timeoutMs);
-		}
 
-		return () => {
-			clearTimeout(timeout);
-		};
+			return () => {
+				clearTimeout(timeout);
+			};
+		}
 	});
 </script>
 


### PR DESCRIPTION
The timeout variable and its related clearTimeout function have been moved inside the effect function. This change improves the readability of the code and keeps the timeout logic encapsulated within the effect where it's used.
