### PR TITLE
refactor(params): refactor match function for param types

### DIFF
--- a/src/params/type.ts
+++ b/src/params/type.ts
@@ -1,3 +1,5 @@
-export function match(param: string): param is 'sync' | 'async' {
-	return ['sync', 'async'].includes(param);
+const PARAM_TYPE_ARRAY = ['sync', 'async'] as const;
+type ParamType = typeof PARAM_TYPE_ARRAY[number];
+export function match(param: string): param is ParamType {
+	return PARAM_TYPE_ARRAY.includes(param as ParamType);
 }


### PR DESCRIPTION
The match function in params/type.ts has been refactored to use a constant array and a type derived from it. This makes the code more maintainable and type-safe.