### PR TITLE
feat: Add lazy loading to images

### DIFF
--- a/src/lib/components/TweetHeader.svelte
+++ b/src/lib/components/TweetHeader.svelte
@@ -22,6 +22,7 @@
 				style:margin-bottom='0'
 				alt={user.name}
 				height={48}
+				loading='lazy'
 				src={user.profile_image_url_https}
 				width={48}
 			/>

--- a/src/lib/components/TweetMedia.svelte
+++ b/src/lib/components/TweetMedia.svelte
@@ -53,7 +53,13 @@
 				>
 					<!-- svelte-ignore element_invalid_self_closing_tag -->
 					<div style={getSkeletonStyle(media, length)} class='skeleton' />
-					<img class='image' alt={media.ext_alt_text || 'Image'} draggable src={getMediaUrl(media, 'small')} />
+					<img
+						class='image'
+						alt={media.ext_alt_text || 'Image'}
+						draggable
+						loading='lazy'
+						src={getMediaUrl(media, 'small')}
+					/>
 				</a>
 			{:else}
 				<div class='mediaContainer'>

--- a/src/lib/components/quoted/Header.svelte
+++ b/src/lib/components/quoted/Header.svelte
@@ -24,6 +24,7 @@
 			<img
 				alt={user.name}
 				height={20}
+				loading='lazy'
 				src={user.profile_image_url_https}
 				width={20}
 			/>


### PR DESCRIPTION
This commit adds the 'loading=lazy' attribute to various image elements across the project. This change will help improve the performance of the web page by deferring the loading of off-screen images until the user scrolls near them.