### PR TITLE
feat: add delay to async tweet loading

### DIFF
--- a/src/routes/[_type=type]/[id]/+page.server.ts
+++ b/src/routes/[_type=type]/[id]/+page.server.ts
@@ -1,3 +1,4 @@
+import { delay } from '@std/async';
 import { error } from '@sveltejs/kit';
 import type { RequestEvent } from './$types';
 import { getTweet } from '$lib/api';
@@ -12,7 +13,7 @@ export async function load({ params }: RequestEvent) {
 	const tweet = getTweet(id);
 
 	return {
-		tweet: _type === 'sync' ? await tweet : tweet,
+		tweet: _type === 'sync' ? await tweet : delay(1500).then(async () => tweet),
 		type: _type,
 	};
 }

--- a/src/routes/[_type=type]/[id]/+page.svelte
+++ b/src/routes/[_type=type]/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang='ts'>
-	import { delay } from '@std/async';
 	import ToggleDark from './ToggleDark.svelte';
 	import {
 		SvelteTweet,
@@ -12,11 +11,6 @@
 	const { tweet, type } = data;
 
 	let isDark = $state(false);
-
-	async function delayedTweet() {
-		await delay(1500);
-		return tweet;
-	}
 </script>
 
 {#snippet renderTweet(tweet: Tweet | undefined)}
@@ -33,7 +27,7 @@
 	{#if type === 'sync'}
 		{@render renderTweet(tweet as Awaited<typeof tweet>)}
 	{:else}
-		{#await delayedTweet()}
+		{#await tweet}
 			<SvelteTweetSkeleton />
 		{:then tweet}
 			{@render renderTweet(tweet)}


### PR DESCRIPTION
This commit introduces a delay to the asynchronous loading of tweets.
The delay is implemented in the server-side code, removing the need for
a delay function in the Svelte component. This results in cleaner,
more maintainable code.
