### PR TITLE
refactor(VerifiedBadge): change import path

### DIFF
--- a/src/lib/components/quoted/Header.svelte
+++ b/src/lib/components/quoted/Header.svelte
@@ -1,6 +1,6 @@
 <script lang='ts'>
 	import type { EnrichedQuotedTweet } from 'react-tweet';
-	import VerifiedBadge from '$components/VerifiedBadge.svelte';
+	import VerifiedBadge from '../VerifiedBadge.svelte';
 
 	type Props = { tweet: EnrichedQuotedTweet };
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -25,7 +25,6 @@ const config = {
 
 		alias: {
 			$: relativePath('src'),
-			$components: relativePath('src/lib/components'),
 		},
 	},
 };


### PR DESCRIPTION
The import path for VerifiedBadge in Header.svelte has been changed
from an alias to a relative path. The alias for $components in
svelte.config.js has also been removed.
