### PR TITLE
feat: Add navigation and example page

### DIFF
--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,18 @@
 	let isAsync = $state(false);
 </script>
 
+<div class='nav'>
+	<h1>
+		<a href='https://github.com/ryoppippi/svelte-tweet'> Svelte Tweet </a>
+	</h1>
+</div>
+
+<div class='nav'>
+	<a href='/examples'>
+		examples
+	</a>
+</div>
+
 <form
 	action="/{isAsync ? 'async' : 'sync'}/{id}"
 	method='GET'
@@ -24,7 +36,7 @@
 	flex-direction: column;
     justify-content: center;
     align-items: center;
-    height: 100vh;
+    height: 60vh;
   }
 
   form > div {
@@ -41,4 +53,16 @@
     padding: 0.5rem 1rem;
     font-size: 1rem;
   }
+
+  .nav {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+  }
+
+  .nav a {
+	color: var(--text-color);
+	font-size: 2rem;
+  }
+
 </style>

--- a/src/routes/[_type=type]/[id]/+layout.server.ts
+++ b/src/routes/[_type=type]/[id]/+layout.server.ts
@@ -1,0 +1,1 @@
+export const prerender = false;

--- a/src/routes/examples/+page.server.ts
+++ b/src/routes/examples/+page.server.ts
@@ -1,0 +1,28 @@
+import { error } from '@sveltejs/kit';
+import { type Tweet, getTweet } from '$lib/api';
+
+const IDS = [
+	'1808900954730942940', // tweet with a video
+	'849813577770778624', // tweet with image and without quote
+	'1629307668568633344', // defalut react-tweeet(including quote)
+] as const satisfies string[];
+
+export async function load() {
+	const tweets: { id: string; tweet: Tweet }[] = [];
+	try {
+		for (const id of IDS) {
+			const tweet = await getTweet(id);
+
+			if (tweet == null) {
+				return error(404, `Tweet not found ${id}`);
+			}
+
+			tweets.push({ id, tweet });
+		}
+
+		return { tweets };
+	}
+	catch {
+		return error(500, 'Could not load tweet');
+	}
+}

--- a/src/routes/examples/+page.svelte
+++ b/src/routes/examples/+page.svelte
@@ -1,0 +1,48 @@
+<script lang='ts'>
+	import ToggleDark from '../ToggleDark.svelte';
+	import {
+		SvelteTweet,
+	} from '$lib';
+
+	const { data } = $props();
+	const { tweets } = data;
+
+	let isDark = $state(false);
+</script>
+
+<div class='desc'>
+	These tweets are statically generated.<br />
+	Let's disable JavaScript and reload the page to see the tweets.
+</div>
+
+<div id='container'>
+	<ToggleDark bind:isDark />
+	{#each tweets as { tweet, id } (id)}
+		<div id={id}>
+			<h1>
+				<a href='#{id}'>{id}</a>
+			</h1>
+			<SvelteTweet {tweet} />
+		</div>
+	{/each}
+</div>
+
+<style>
+  .desc {
+    margin-bottom: 1rem;
+    font-size: 2rem;
+    text-align: center;
+  }
+
+	#container {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		flex-direction: column;
+	}
+
+  a {
+    text-decoration: none;
+    color: var(--text-color);
+  }
+</style>


### PR DESCRIPTION
This commit introduces a navigation bar to the application and an examples page. The navigation bar includes a link to the GitHub repository and a link to the examples page. The examples page statically generates a set of tweets for demonstration purposes.