### PR TITLE
docs(TweetMediaVideo): ignore non-reactive update

### DIFF
--- a/src/lib/components/TweetMediaVideo.svelte
+++ b/src/lib/components/TweetMediaVideo.svelte
@@ -15,6 +15,8 @@
 	let timeout = $state(0);
 
 	const mp4Video = getMp4Video(media);
+
+	// svelte-ignore non_reactive_update
 	let video: HTMLVideoElement;
 
 	$effect(() => {


### PR DESCRIPTION
This commit adds a svelte-ignore comment to ignore the non-reactive
update warning for the 'video' variable in TweetMediaVideo.svelte.
