### PR TITLE
feat: Add esm-env for browser detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"svelte": "^5.0.0"
 	},
 	"dependencies": {
+		"esm-env": "^1.0.0",
 		"react-tweet": "^3.2.1"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      esm-env:
+        specifier: ^1.0.0
+        version: 1.0.0
       react-tweet:
         specifier: ^3.2.1
         version: 3.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/lib/components/TweetMediaVideo.svelte
+++ b/src/lib/components/TweetMediaVideo.svelte
@@ -2,6 +2,7 @@
 	import type { EnrichedQuotedTweet, EnrichedTweet } from 'react-tweet';
 	import type { MediaAnimatedGif, MediaVideo	} from 'react-tweet/api';
 	import { getMediaUrl, getMp4Video } from 'react-tweet';
+	import { BROWSER } from 'esm-env';
 
 	type Props = {
 		tweet: EnrichedTweet | EnrichedQuotedTweet;
@@ -27,7 +28,7 @@
 </script>
 
 <!-- current does not work @see https://github.com/sveltejs/kit/issues/11057 -->
-{#if typeof window !== 'undefined'}
+{#if BROWSER}
 	<video
 		bind:this={video}
 		class='image'


### PR DESCRIPTION
This commit introduces the 'esm-env' package to the project. It is used
in 'TweetMediaVideo.svelte' for browser detection, replacing the previous
method of checking 'typeof window'. This change is necessary due to an
issue with Svelte Kit (https://github.com/sveltejs/kit/issues/11057).
