### PR TITLE
feat(TweetContainer): refactor to accept HTMLAttributes

### DIFF
--- a/src/lib/components/TweetContainer.svelte
+++ b/src/lib/components/TweetContainer.svelte
@@ -1,19 +1,14 @@
-<script context='module'>
-	export const className = `tweet-container`;
-</script>
-
 <script lang='ts'>
 	import type { Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
 	import 'react-tweet/theme.css';
 
-	type Props = {
-		children: Snippet;
-	};
-	const { children }: Props = $props();
+	type Props = { children: Snippet } & HTMLAttributes<HTMLDivElement>;
+	const { children, ...rest }: Props = $props();
 </script>
 
 <div
-	class={className}
+	{...rest}
 	class:react-tweet-theme={true}
 	class:root={true}
 >

--- a/src/lib/components/TweetSkeleton.svelte
+++ b/src/lib/components/TweetSkeleton.svelte
@@ -8,7 +8,7 @@
   <span class='skeleton' {...rest} />
 {/snippet}
 
-<TweetContainer>
+<TweetContainer style='pointer-events: none; padding-bottom: 0.25rem;'>
 	{@render skeleton({ style: 'height: 3rem; margin-bottom: 0.75rem;' })}
 	{@render skeleton({ style: 'height: 6rem; margin: 0.5rem 0;' })}
 
@@ -22,12 +22,6 @@
 </TweetContainer>
 
 <style>
-:global{
-  .tweet-container {
-    pointer-events: none;
-    padding-bottom: 0.25rem;
-  }
-}
 .skeleton {
   display: block;
   width: 100%;


### PR DESCRIPTION
The TweetContainer component has been refactored to accept HTMLAttributes.
This allows for more flexibility when using the component. The className
export has been removed and replaced with the spread operator to apply
any passed HTMLAttributes. The TweetSkeleton component has been updated
to pass styles directly to the TweetContainer.
