### PR TITLE
feat(TweetSkeleton): move styles to global scope

### DIFF
--- a/src/lib/components/TweetSkeleton.svelte
+++ b/src/lib/components/TweetSkeleton.svelte
@@ -8,7 +8,7 @@
   <span class='skeleton' {...rest} />
 {/snippet}
 
-<TweetContainer style='pointer-events: none; padding-bottom: 0.25rem;'>
+<TweetContainer class='tweet-container-skeleton'>
 	{@render skeleton({ style: 'height: 3rem; margin-bottom: 0.75rem;' })}
 	{@render skeleton({ style: 'height: 6rem; margin: 0.5rem 0;' })}
 
@@ -22,6 +22,13 @@
 </TweetContainer>
 
 <style>
+:global {
+  .tweet-container-skeleton {
+    pointer-events: none;
+    padding-bottom: 0.25rem;
+  }
+}
+
 .skeleton {
   display: block;
   width: 100%;


### PR DESCRIPTION
Moved the inline styles for TweetContainer in TweetSkeleton.svelte to a
global scope by creating a new class 'tweet-container-skeleton'. This
change improves the maintainability and reusability of the styles.
