### PR TITLE
feat(svelte.config): disable inspector

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -21,6 +21,10 @@ const config = {
 		runes: true,
 	},
 
+	vitePlugin: {
+		inspector: false,
+	},
+
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.


### PR DESCRIPTION
This commit introduces a new configuration for vitePlugin in the
svelte.config.js file. The inspector property is set to false.
