### PR TITLE
feat(package.json): Change source directory to src/lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"!dist/**/*.spec.*",
 		"!dist/**/*.test.*",
 		"dist",
-		"src"
+		"src/lib/"
 	],
 	"svelte": "./dist/index.js",
 	"scripts": {


### PR DESCRIPTION
The source directory in package.json has been changed from 'src' to
'src/lib'. This change is necessary to ensure that only the necessary
files are included when the package is distributed.
