### PR TITLE
feat: upgrade svelte-preprocess-import-css and refactor CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	"devDependencies": {
 		"@antfu/ni": "^0.22.0",
 		"@ryoppippi/eslint-config": "npm:@jsr/ryoppippi__eslint-config@^0.0.21",
-		"@ryoppippi/svelte-preprocess-import-css": "npm:@jsr/ryoppippi__svelte-preprocess-import-css@^0.2.0",
+		"@ryoppippi/svelte-preprocess-import-css": "npm:@jsr/ryoppippi__svelte-preprocess-import-css@^0.3.0",
 		"@std/async": "npm:@jsr/std__async@^1.0.1",
 		"@sveltejs/adapter-auto": "^3.2.2",
 		"@sveltejs/kit": "^2.5.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: npm:@jsr/ryoppippi__eslint-config@^0.0.21
         version: '@jsr/ryoppippi__eslint-config@0.0.21(@vue/compiler-sfc@3.4.35)(eslint-plugin-format@0.1.2(eslint@9.8.0))(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.202))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.202))(svelte@5.0.0-next.202)(typescript@5.5.4)'
       '@ryoppippi/svelte-preprocess-import-css':
-        specifier: npm:@jsr/ryoppippi__svelte-preprocess-import-css@^0.2.0
-        version: '@jsr/ryoppippi__svelte-preprocess-import-css@0.2.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.202)(vite@5.3.5))'
+        specifier: npm:@jsr/ryoppippi__svelte-preprocess-import-css@^0.3.0
+        version: '@jsr/ryoppippi__svelte-preprocess-import-css@0.3.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.202)(vite@5.3.5))'
       '@std/async':
         specifier: npm:@jsr/std__async@^1.0.1
         version: '@jsr/std__async@1.0.1'
@@ -388,8 +388,8 @@ packages:
   '@jsr/ryoppippi__eslint-config@0.0.21':
     resolution: {integrity: sha512-qUSqd01B3n4Mw8su5T9oUZ3LPUUG95ybThuksz2dcPjygsex0FzFgzFLF4gaXMszyyj2Or+T1a4nji6bf+lJwQ==, tarball: https://npm.jsr.io/~/11/@jsr/ryoppippi__eslint-config/0.0.21.tgz}
 
-  '@jsr/ryoppippi__svelte-preprocess-import-css@0.2.0':
-    resolution: {integrity: sha512-kSsMzIuLyIbNgTHitH3yPMfJUCBWC5mrRLB/ETmOjb/0uoL0FaD82ldDR1tXJ9JFOvTvPJuiCP6mC5gOsGnBeg==, tarball: https://npm.jsr.io/~/11/@jsr/ryoppippi__svelte-preprocess-import-css/0.2.0.tgz}
+  '@jsr/ryoppippi__svelte-preprocess-import-css@0.3.0':
+    resolution: {integrity: sha512-3nu8/y7LnPogUDBtR3A9aawzHYRad0RiBJ+Aww6nVTCZDX/tYX4yrTWIjMhPepjbXx7ANaKyhTpyFAgehJDZYQ==, tarball: https://npm.jsr.io/~/11/@jsr/ryoppippi__svelte-preprocess-import-css/0.3.0.tgz}
 
   '@jsr/std__async@1.0.1':
     resolution: {integrity: sha512-NwX2UXmpHrp5iJJGlC80PZ2bcflvkOtKjtGAHN6dqpuYoxJpEliy8fMJOLofvyulWvlY1SkDD9da9uS00ERfpg==, tarball: https://npm.jsr.io/~/11/@jsr/std__async/1.0.1.tgz}
@@ -2652,7 +2652,7 @@ snapshots:
       - typescript
       - vitest
 
-  '@jsr/ryoppippi__svelte-preprocess-import-css@0.2.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.202)(vite@5.3.5))':
+  '@jsr/ryoppippi__svelte-preprocess-import-css@0.3.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.202)(vite@5.3.5))':
     dependencies:
       '@sveltejs/kit': 2.5.19(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.202)(vite@5.3.5))(svelte@4.2.18)(vite@5.3.5)
       css-selector-extract: 4.0.1

--- a/src/lib/components/TweetSkeleton.svelte
+++ b/src/lib/components/TweetSkeleton.svelte
@@ -22,12 +22,9 @@
 </TweetContainer>
 
 <style>
-:global {
-  .tweet-container-skeleton {
-    pointer-events: none;
-    padding-bottom: 0.25rem;
-  }
-}
+	:global {
+		@import "$rt/tweet-skeleton.module.css?.root=.tweet-container-skeleton" scoped;
+	}
 
-	@import "$rt/tweet-skeleton.module.css" scoped;
+	@import "$rt/skeleton.module.css" scoped;
 </style>


### PR DESCRIPTION
This commit includes two main changes. First, the
"@ryoppippi/svelte-preprocess-import-css" package is upgraded from
version 0.2.0 to 0.3.0 in both package.json and pnpm-lock.yaml files.

Second, the CSS in TweetSkeleton.svelte is refactored. The global
styles for ".tweet-container-skeleton" are now imported from
"tweet-skeleton.module.css" instead of being defined in the file.
Also, the styles are now imported from "skeleton.module.css" instead
of "tweet-skeleton.module.css".
