### PR TITLE
feat(TweetActions/TweetCopyActions): use global scope for CSS import

### DIFF
--- a/src/lib/components/TweetActions.svelte
+++ b/src/lib/components/TweetActions.svelte
@@ -47,5 +47,7 @@
 </div>
 
 <style>
-	@import "$rt_tw/tweet-actions.module.css" scoped;
+	:global {
+		@import "$rt_tw/tweet-actions.module.css" scoped;
+	}
 </style>

--- a/src/lib/components/TweetActionsCopy.svelte
+++ b/src/lib/components/TweetActionsCopy.svelte
@@ -47,7 +47,3 @@
 		{copied ? 'Copied!' : 'Copy link'}
 	</span>
 </button>
-
-<style>
-	@import "$rt_tw/tweet-actions.module.css" scoped;
-</style>


### PR DESCRIPTION
The CSS import in TweetActions.svelte and TweetActionsCopy.svelte has
been
modified. In TweetActions.svelte, the import is now within a :global
scope.
In TweetActionsCopy.svelte, the import statement has been removed.

feat(TweetActionsCopy): add styles import

This commit introduces a new style import in the
TweetActionsCopy.svelte component. The imported styles are scoped
globally, enhancing the component's visual presentation.
